### PR TITLE
feat: improve class schedule modal positioning

### DIFF
--- a/src/utils/calculateModalPosition.ts
+++ b/src/utils/calculateModalPosition.ts
@@ -1,42 +1,86 @@
 export interface ModalPosition {
-    x: number;
-    y: number;
-    slideDirection: 'left' | 'right' | 'center';
-  }
-  
-  interface BoxLike {
-    x?: number;
-    y?: number;
-    clientX?: number;
-    clientY?: number;
-  }
-  
-  export function calculateModalPosition(box?: BoxLike, modalWidth = 384): ModalPosition {
-    const screenW = window.innerWidth;
-    const scrollX = window.pageXOffset || document.documentElement.scrollLeft;
-    const scrollY = window.pageYOffset || document.documentElement.scrollTop;
-  
-    let pageX =
-      box?.x ??
-      (box?.clientX !== undefined ? box.clientX + scrollX : scrollX + screenW / 2);
-    const pageY =
-      box?.y ??
-      (box?.clientY !== undefined ? box.clientY + scrollY : scrollY + 160);
-  
-    const viewportX = pageX - scrollX;
-    const leftEnough = viewportX > modalWidth + 40;
-    const rightEnough = screenW - viewportX > modalWidth + 40;
-    const slideDirection: 'left' | 'right' | 'center' =
-      rightEnough ? 'right' : leftEnough ? 'left' : 'center';
-  
-    if (rightEnough) {
-      pageX += 20;
-    } else if (leftEnough) {
-      pageX -= modalWidth + 20;
+  x: number;
+  y: number;
+  slideDirection: 'left' | 'right' | 'center';
+}
+
+interface BoxLike {
+  x?: number;
+  y?: number;
+  clientX?: number;
+  clientY?: number;
+  /**
+   * Optional event target used to locate the closest time slot element.
+   */
+  target?: EventTarget | null;
+}
+
+/**
+ * Calculate the best position for the add-event modal. The logic tries to keep
+ * the modal near the interacted time slot and prefers placing it on the right
+ * side, then left side, and finally centered below the slot.
+ */
+export function calculateModalPosition(
+  box?: BoxLike,
+  modalWidth = 384,
+): ModalPosition {
+  const screenWidth = window.innerWidth;
+
+  // Initial coordinates: use box values when available, otherwise fall back
+  // to the center of the screen.
+  let modalX = box?.clientX ?? box?.x ?? screenWidth / 2;
+  let modalY = box?.clientY ?? box?.y ?? window.innerHeight / 2;
+
+  // Try to find the related time slot element to determine optimal placement.
+  const element =
+    (box?.target instanceof HTMLElement
+      ? box.target
+      : document.elementFromPoint(modalX, modalY)) as HTMLElement | null;
+  const timeSlot = element?.closest(
+    '.rbc-time-slot, .rbc-day-slot, .rbc-date-cell',
+  ) as HTMLElement | null;
+
+  if (timeSlot) {
+    const rect = timeSlot.getBoundingClientRect();
+    const leftSpace = rect.left;
+    const rightSpace = screenWidth - rect.right;
+
+    let slideDirection: 'left' | 'right' | 'center';
+    if (rightSpace >= modalWidth + 30) {
+      modalX = rect.right + 20;
+      modalY = rect.top;
+      slideDirection = 'right';
+    } else if (leftSpace >= modalWidth + 30) {
+      modalX = rect.left - modalWidth - 20;
+      modalY = rect.top;
+      slideDirection = 'left';
     } else {
-      pageX =
-        scrollX + Math.max(10, Math.min(viewportX - modalWidth / 2, screenW - modalWidth - 10));
+      modalX = Math.max(
+        10,
+        Math.min(rect.left + (rect.width - modalWidth) / 2, screenWidth - modalWidth - 10),
+      );
+      modalY = rect.bottom + 10;
+      slideDirection = 'center';
     }
-  
-    return { x: pageX, y: pageY, slideDirection };
+
+    return { x: modalX, y: modalY, slideDirection };
   }
+
+  // Fallback: place modal relative to viewport when no slot is found.
+  const leftEnough = modalX > modalWidth + 40;
+  const rightEnough = screenWidth - modalX > modalWidth + 40;
+  let slideDirection: 'left' | 'right' | 'center' = 'center';
+
+  if (rightEnough) {
+    modalX += 20;
+    slideDirection = 'right';
+  } else if (leftEnough) {
+    modalX -= modalWidth + 20;
+    slideDirection = 'left';
+  } else {
+    modalX = Math.max(10, Math.min(modalX - modalWidth / 2, screenWidth - modalWidth - 10));
+    slideDirection = 'center';
+  }
+
+  return { x: modalX, y: modalY, slideDirection };
+}


### PR DESCRIPTION
## Summary
- refine modal position calculation for class schedule to align with selected slot
- track mouse position in class schedule page and use it when computing modal location

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many type and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9136fa57c83278582c6b9ec8674f6