### PR TITLE
Remove duplicate schedule handlers and surface API errors

### DIFF
--- a/src/app/class/schedule/components/AddEventModal.tsx
+++ b/src/app/class/schedule/components/AddEventModal.tsx
@@ -67,7 +67,7 @@ interface AddEventModalProps {
   isOpen: boolean;
   onClose: () => void;
   onTimeChange: (startTime: string, endTime: string) => void;
-  onSave: (event: Partial<ScheduleEvent> & {
+  onSave?: (event: Partial<ScheduleEvent> & {
     repeat?: 'none' | 'weekly';
     subject?: string;
     campus?: string;
@@ -506,7 +506,7 @@ export default function AddEventModal({
     }
 
     // 兼容旧逻辑：组装 payload 调用父 onSave
-    onSave({
+    onSave?.({
       start,
       end,
       type: eventType,


### PR DESCRIPTION
## Summary
- Simplify class schedule page by removing unused add/edit handlers
- Display server-side validation errors using `apiErrors` overlay
- Allow `AddEventModal` to omit `onSave` when strategies manage saving

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a5aa75a48327bc49b7c13b55e94b