### PR TITLE
feat: add exam management pages

### DIFF
--- a/src/app/exam/edit/page.tsx
+++ b/src/app/exam/edit/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { PERMISSIONS } from '@/types/auth';
+import {
+  getExamEditInfo,
+  editExam,
+  addChangePrice,
+  updateChangePrice,
+  deleteChangePrice,
+  deleteInnerSignup,
+  deletePublicSignup,
+} from '@/services/auth';
+import Button from '@/components/Button';
+import {
+  PlusIcon,
+  PencilIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+export default function ExamEditPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const examId = searchParams.get('id');
+  const { hasPermission } = useAuth();
+  const canEdit = hasPermission(PERMISSIONS.EDIT_EXAMS);
+
+  const [loading, setLoading] = useState(true);
+  const [info, setInfo] = useState<any>(null);
+  const [form, setForm] = useState({
+    record_id: 0,
+    exam_name: '',
+    base_price: 0,
+    exam_location: '',
+    exam_topic: '',
+    exam_topic_id: 0,
+    exam_code: '',
+    period: 0,
+    exam_type: 0,
+    exam_time: 0,
+    exam_time_2: 0,
+    exam_time_3: 0,
+    alipay_account: 0,
+  });
+  const [priceChanges, setPriceChanges] = useState<any[]>([]);
+  const [newChange, setNewChange] = useState({ change_price: 0, change_time: 0 });
+  const [editingChange, setEditingChange] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (examId && canEdit) {
+      loadInfo();
+    }
+  }, [examId, canEdit]);
+
+  const loadInfo = async () => {
+    if (!examId) return;
+    setLoading(true);
+    const resp = await getExamEditInfo(Number(examId));
+    if (resp.code === 200 && resp.data) {
+      setInfo(resp.data);
+      const ed = resp.data.exam_data;
+      setForm({
+        record_id: ed.id,
+        exam_name: ed.name || '',
+        base_price: ed.base_price || 0,
+        exam_location: ed.location || '',
+        exam_topic: ed.topic || '',
+        exam_topic_id: ed.topic_id || 0,
+        exam_code: ed.code || '',
+        period: ed.period || 0,
+        exam_type: ed.type || 0,
+        exam_time: ed.time || 0,
+        exam_time_2: ed.time_2 || 0,
+        exam_time_3: ed.time_3 || 0,
+        alipay_account: ed.alipay_account || 0,
+      });
+      setPriceChanges(resp.data.price_data || []);
+    }
+    setLoading(false);
+  };
+
+  const handleSave = async () => {
+    const resp = await editExam(form);
+    if (resp.code === 200) {
+      loadInfo();
+    }
+  };
+
+  const handleAddChange = async () => {
+    const resp = await addChangePrice({ exam_id: form.record_id, ...newChange });
+    if (resp.code === 200) {
+      setNewChange({ change_price: 0, change_time: 0 });
+      loadInfo();
+    }
+  };
+
+  const handleUpdateChange = async () => {
+    if (!editingChange) return;
+    const resp = await updateChangePrice({
+      record_id: editingChange.id,
+      change_price: editingChange.price,
+      change_time: editingChange.time,
+    });
+    if (resp.code === 200) {
+      setEditingChange(null);
+      loadInfo();
+    }
+  };
+
+  const handleDeleteChange = async (id: number) => {
+    await deleteChangePrice({ record_id: id });
+    loadInfo();
+  };
+
+  const handleDeleteInner = async (id: number) => {
+    await deleteInnerSignup({ record_id: id });
+    loadInfo();
+  };
+
+  const handleDeletePublic = async (id: number) => {
+    await deletePublicSignup({ record_id: id });
+    loadInfo();
+  };
+
+  if (!canEdit) {
+    return <div className="p-4">Permission denied</div>;
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold mb-2">Edit Exam</h1>
+      <div className="grid grid-cols-2 gap-2">
+        <input
+          className="border p-1"
+          placeholder="Name"
+          value={form.exam_name}
+          onChange={(e) => setForm({ ...form, exam_name: e.target.value })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Base Price"
+          type="number"
+          value={form.base_price}
+          onChange={(e) => setForm({ ...form, base_price: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Location"
+          value={form.exam_location}
+          onChange={(e) => setForm({ ...form, exam_location: e.target.value })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Topic"
+          value={form.exam_topic}
+          onChange={(e) => setForm({ ...form, exam_topic: e.target.value })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Code"
+          value={form.exam_code}
+          onChange={(e) => setForm({ ...form, exam_code: e.target.value })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Period"
+          type="number"
+          value={form.period}
+          onChange={(e) => setForm({ ...form, period: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Type"
+          type="number"
+          value={form.exam_type}
+          onChange={(e) => setForm({ ...form, exam_type: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Time"
+          type="number"
+          value={form.exam_time}
+          onChange={(e) => setForm({ ...form, exam_time: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Time 2"
+          type="number"
+          value={form.exam_time_2}
+          onChange={(e) => setForm({ ...form, exam_time_2: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Time 3"
+          type="number"
+          value={form.exam_time_3}
+          onChange={(e) => setForm({ ...form, exam_time_3: Number(e.target.value) })}
+        />
+        <input
+          className="border p-1"
+          placeholder="Alipay Account"
+          type="number"
+          value={form.alipay_account}
+          onChange={(e) => setForm({ ...form, alipay_account: Number(e.target.value) })}
+        />
+      </div>
+      <div>
+        <Button onClick={handleSave}>Save</Button>
+      </div>
+
+      <div className="mt-4">
+        <h2 className="font-semibold mb-2">Price Changes</h2>
+        <ul className="space-y-2">
+          {priceChanges.map((pc) => (
+            <li key={pc.id} className="flex items-center space-x-2">
+              {editingChange && editingChange.id === pc.id ? (
+                <>
+                  <input
+                    className="border p-1 w-24"
+                    type="number"
+                    value={editingChange.price}
+                    onChange={(e) => setEditingChange({ ...editingChange, price: Number(e.target.value) })}
+                  />
+                  <input
+                    className="border p-1 w-40"
+                    type="number"
+                    value={editingChange.time}
+                    onChange={(e) => setEditingChange({ ...editingChange, time: Number(e.target.value) })}
+                  />
+                  <Button variant="secondary" onClick={handleUpdateChange}>
+                    <PencilIcon className="w-4 h-4" />
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <span>{pc.price}</span>
+                  <span>{pc.time}</span>
+                  <Button variant="secondary" onClick={() => setEditingChange(pc)}>
+                    <PencilIcon className="w-4 h-4" />
+                  </Button>
+                </>
+              )}
+              <Button variant="secondary" onClick={() => handleDeleteChange(pc.id)}>
+                <TrashIcon className="w-4 h-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+        <div className="flex items-center space-x-2 mt-2">
+          <input
+            className="border p-1 w-24"
+            type="number"
+            placeholder="Price"
+            value={newChange.change_price}
+            onChange={(e) => setNewChange({ ...newChange, change_price: Number(e.target.value) })}
+          />
+          <input
+            className="border p-1 w-40"
+            type="number"
+            placeholder="Time"
+            value={newChange.change_time}
+            onChange={(e) => setNewChange({ ...newChange, change_time: Number(e.target.value) })}
+          />
+          <Button variant="secondary" onClick={handleAddChange}>
+            <PlusIcon className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <h2 className="font-semibold mb-2">Inner Students</h2>
+        <ul className="space-y-1">
+          {info?.inner_student_data?.map((s: any) => (
+            <li key={s.id} className="flex justify-between">
+              <span>{s.student_name}</span>
+              <Button variant="secondary" onClick={() => handleDeleteInner(s.id)}>
+                <TrashIcon className="w-4 h-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-4">
+        <h2 className="font-semibold mb-2">Public Students</h2>
+        <ul className="space-y-1">
+          {info?.outer_student_data?.map((s: any) => (
+            <li key={s.id} className="flex justify-between">
+              <span>{s.name}</span>
+              <Button variant="secondary" onClick={() => handleDeletePublic(s.id)}>
+                <TrashIcon className="w-4 h-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/exam/page.tsx
+++ b/src/app/exam/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { PERMISSIONS } from '@/types/auth';
+import {
+  getExamList,
+  addNewExam,
+  updateExamStatus,
+  deleteExam,
+  type ExamListItem,
+  type AddExamParams,
+} from '@/services/auth';
+import {
+  PlusIcon,
+  PencilIcon,
+  TrashIcon,
+  XMarkIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline';
+import Button from '@/components/Button';
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+export default function ExamPage() {
+  const router = useRouter();
+  const { hasPermission } = useAuth();
+  const canEdit = hasPermission(PERMISSIONS.EDIT_EXAMS);
+
+  const [loading, setLoading] = useState(true);
+  const [exams, setExams] = useState<ExamListItem[]>([]);
+  const [disabledExams, setDisabledExams] = useState<ExamListItem[]>([]);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [addForm, setAddForm] = useState<AddExamParams>({
+    exam_name: '',
+    exam_location: '',
+    exam_topic: '',
+    exam_code: '',
+  });
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      const resp = await getExamList();
+      if (resp.status === 200) {
+        setExams(resp.data.active || []);
+        setDisabledExams(resp.data.disabled || []);
+      } else {
+        setError(resp.message || 'Failed to load exams');
+      }
+    } catch (e) {
+      console.error(e);
+      setError('Failed to load exams');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (canEdit) {
+      loadData();
+    }
+  }, [canEdit]);
+
+  const handleAddExam = async () => {
+    setActionLoading(true);
+    const resp = await addNewExam(addForm);
+    setActionLoading(false);
+    if (resp.code === 200) {
+      setShowAddModal(false);
+      setAddForm({ exam_name: '', exam_location: '', exam_topic: '', exam_code: '' });
+      loadData();
+    } else {
+      setError(resp.message || '添加考试失败');
+    }
+  };
+
+  const handleToggleStatus = async (exam: ExamListItem, disable: boolean) => {
+    setActionLoading(true);
+    await updateExamStatus({ record_id: exam.id, status: disable ? 1 : 0 });
+    setActionLoading(false);
+    loadData();
+  };
+
+  const handleDelete = async (exam: ExamListItem) => {
+    if (!confirm('确认删除该考试?')) return;
+    setActionLoading(true);
+    await deleteExam({ record_id: exam.id });
+    setActionLoading(false);
+    loadData();
+  };
+
+  if (!canEdit) {
+    return <div className="p-4">Permission denied</div>;
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-semibold">Exams</h1>
+        <Button onClick={() => setShowAddModal(true)} disabled={!canEdit}>
+          <PlusIcon className="w-4 h-4 mr-1" /> Add Exam
+        </Button>
+      </div>
+
+      {error && <div className="text-red-500">{error}</div>}
+
+      <div>
+        <h2 className="font-semibold mb-2">Active</h2>
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Name</th>
+              <th className="px-2 py-1 text-left">Code</th>
+              <th className="px-2 py-1 text-left">Price</th>
+              <th className="px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {exams.map((exam) => (
+              <tr key={exam.id} className="border-b">
+                <td className="px-2 py-1">{exam.name}</td>
+                <td className="px-2 py-1">{exam.code}</td>
+                <td className="px-2 py-1">{exam.price}</td>
+                <td className="px-2 py-1 flex space-x-2 justify-center">
+                  <Button
+                    variant="secondary"
+                    onClick={() => router.push(`/exam/edit?id=${exam.id}`)}
+                  >
+                    <PencilIcon className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => handleToggleStatus(exam, true)}
+                  >
+                    <XMarkIcon className="w-4 h-4" />
+                  </Button
+                  >
+                  <Button
+                    variant="secondary"
+                    onClick={() => handleDelete(exam)}
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h2 className="font-semibold mb-2">Disabled</h2>
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Name</th>
+              <th className="px-2 py-1 text-left">Code</th>
+              <th className="px-2 py-1 text-left">Price</th>
+              <th className="px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {disabledExams.map((exam) => (
+              <tr key={exam.id} className="border-b">
+                <td className="px-2 py-1">{exam.name}</td>
+                <td className="px-2 py-1">{exam.code}</td>
+                <td className="px-2 py-1">{exam.price}</td>
+                <td className="px-2 py-1 flex space-x-2 justify-center">
+                  <Button
+                    variant="secondary"
+                    onClick={() => handleToggleStatus(exam, false)}
+                  >
+                    <CheckIcon className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => handleDelete(exam)}
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {showAddModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <div className="bg-white p-4 rounded shadow w-80 space-y-2">
+            <h2 className="text-lg font-semibold">Add Exam</h2>
+            <input
+              className="w-full border p-1"
+              placeholder="Name"
+              value={addForm.exam_name}
+              onChange={(e) => setAddForm({ ...addForm, exam_name: e.target.value })}
+            />
+            <input
+              className="w-full border p-1"
+              placeholder="Location"
+              value={addForm.exam_location}
+              onChange={(e) => setAddForm({ ...addForm, exam_location: e.target.value })}
+            />
+            <input
+              className="w-full border p-1"
+              placeholder="Topic"
+              value={addForm.exam_topic}
+              onChange={(e) => setAddForm({ ...addForm, exam_topic: e.target.value })}
+            />
+            <input
+              className="w-full border p-1"
+              placeholder="Code"
+              value={addForm.exam_code}
+              onChange={(e) => setAddForm({ ...addForm, exam_code: e.target.value })}
+            />
+            <div className="flex justify-end space-x-2 mt-2">
+              <Button variant="secondary" onClick={() => setShowAddModal(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAddExam} disabled={actionLoading}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3070,3 +3070,351 @@ export const deleteClass = async (params: DeleteClassParams): Promise<ApiRespons
     };
   }
 };
+
+// Exam management APIs
+
+export interface ExamListItem {
+  id: number;
+  name: string;
+  code: string;
+  location?: string;
+  topic?: string;
+  price?: number;
+  price_string?: string;
+}
+
+export interface ExamListResponse {
+  status: number;
+  message: string;
+  data: { active: ExamListItem[]; disabled: ExamListItem[] };
+}
+
+export const getExamList = async (): Promise<ExamListResponse> => {
+  try {
+    const response = await fetch('/api/exam/get_exam_list', {
+      method: 'GET',
+      headers: getAuthHeader(),
+    });
+    const data = await response.json();
+    return {
+      status: data.status === 0 ? 200 : data.status,
+      message: data.message || '',
+      data: data.data || { active: [], disabled: [] },
+    };
+  } catch (error) {
+    console.error('获取考试列表失败:', error);
+    return {
+      status: 500,
+      message: '获取考试列表失败',
+      data: { active: [], disabled: [] },
+    };
+  }
+};
+
+export interface AddExamParams {
+  exam_name: string;
+  exam_location: string;
+  exam_topic: string;
+  exam_code: string;
+}
+
+export const addNewExam = async (params: AddExamParams): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/add_new_exam', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('添加考试失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '添加考试失败',
+    };
+  }
+};
+
+export interface UpdateExamStatusParams {
+  record_id: number;
+  status: number; // 0 disable, 1 enable
+}
+
+export const updateExamStatus = async (
+  params: UpdateExamStatusParams
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/update_exam_status', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('更新考试状态失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '更新考试状态失败',
+    };
+  }
+};
+
+export interface DeleteExamParams {
+  record_id: number;
+}
+
+export const deleteExam = async (
+  params: DeleteExamParams
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/delete_exam', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('删除考试失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '删除考试失败',
+    };
+  }
+};
+
+export const getExamEditInfo = async (
+  id: number
+): Promise<{ code: number; message: string; data?: any }> => {
+  try {
+    const response = await fetch(`/api/exam/get_exam_edit_info/${id}`, {
+      method: 'GET',
+      headers: getAuthHeader(),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : data.status,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('获取考试信息失败:', error);
+    return { code: 500, message: '获取考试信息失败' };
+  }
+};
+
+export interface EditExamParams {
+  record_id: number;
+  exam_name: string;
+  base_price: number;
+  exam_location: string;
+  exam_topic: string;
+  exam_topic_id: number;
+  exam_code: string;
+  period: number;
+  exam_type: number;
+  exam_time: number;
+  exam_time_2: number;
+  exam_time_3: number;
+  alipay_account: number;
+}
+
+export const editExam = async (params: EditExamParams): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/edit_exam', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('编辑考试失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '编辑考试失败',
+    };
+  }
+};
+
+export interface ChangePriceParams {
+  record_id?: number;
+  exam_id?: number;
+  change_price: number;
+  change_time: number;
+}
+
+export const addChangePrice = async (
+  params: Omit<ChangePriceParams, 'record_id'> & { exam_id: number }
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/add_change_price', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('添加价格变更失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '添加价格变更失败',
+    };
+  }
+};
+
+export const updateChangePrice = async (
+  params: ChangePriceParams & { record_id: number }
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/update_change_price', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('更新价格变更失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '更新价格变更失败',
+    };
+  }
+};
+
+export const deleteChangePrice = async (
+  params: { record_id: number }
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/delete_change_price', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('删除价格变更失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '删除价格变更失败',
+    };
+  }
+};
+
+export const deleteInnerSignup = async (
+  params: { record_id: number }
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/delete_inner_signup', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('删除内部报名失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '删除内部报名失败',
+    };
+  }
+};
+
+export const deletePublicSignup = async (
+  params: { record_id: number }
+): Promise<ApiResponse> => {
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    };
+    const response = await fetch('/api/exam/delete_public_signup', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(params),
+    });
+    const data = await response.json();
+    return {
+      code: data.status === 0 ? 200 : 400,
+      message: data.message || '',
+      data: data.data,
+    };
+  } catch (error) {
+    console.error('删除公共报名失败:', error);
+    return {
+      code: 500,
+      message: error instanceof Error ? error.message : '删除公共报名失败',
+    };
+  }
+};
+


### PR DESCRIPTION
## Summary
- add exam API helpers for listing and editing exams
- create exam list page with add, toggle status, and delete features
- add exam edit page with price change and signup management

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d7c1cb448327931c23f987f1ce2d